### PR TITLE
fix: replace us-east-1a with us-east-1d in AZ list for Elastic PrivateLink service

### DIFF
--- a/solution-templates/elastic/end-to-end-rag-terraform/solution.tf
+++ b/solution-templates/elastic/end-to-end-rag-terraform/solution.tf
@@ -1,9 +1,22 @@
+terraform {
+  required_providers {
+    ec = {
+      source  = "elastic/ec"
+      version = "0.12.2"
+    }
+  }
+}
+
+provider "ec" {
+  apikey = var.elastic_cloud_api_key
+}
+
 module "vpc" {
     source = "terraform-aws-modules/vpc/aws"
     version = "6.0.1"
     name = "marketplace-elastic"
     cidr = "10.0.0.0/16"
-    azs = ["us-east-1a", "us-east-1b", "us-east-1c"]
+    azs = ["us-east-1b", "us-east-1c", "us-east-1d"]
     private_subnets = ["10.0.10.0/24", "10.0.20.0/24", "10.0.30.0/24"]
     public_subnets = ["10.0.40.0/24", "10.0.50.0/24", "10.0.60.0/24"]
     enable_nat_gateway = true


### PR DESCRIPTION
**Body:**
```
The VPC module hardcodes us-east-1a as one of the availability zones,
but Elastic's PrivateLink service does not operate in us-east-1a.

Verified directly from AWS API:

aws ec2 describe-vpc-endpoint-services \
  --service-names com.amazonaws.vpce.us-east-1.vpce-svc-0e42e1e06ed010238 \
  --query 'ServiceDetails[0].AvailabilityZones' \
  --region us-east-1

Returns: ["us-east-1b", "us-east-1c", "us-east-1d"] — no us-east-1a.

Fix: replace us-east-1a with us-east-1d in solution.tf line 6.

Related to #43 where this was flagged in a comment.